### PR TITLE
RCP-55-RECIPE-SNS-SQS-zipkin-trace-remove

### DIFF
--- a/src/main/java/com/recipia/recipe/aws/AwsSqsListenerService.java
+++ b/src/main/java/com/recipia/recipe/aws/AwsSqsListenerService.java
@@ -1,7 +1,5 @@
 package com.recipia.recipe.aws;
 
-import brave.Span;
-import brave.Tracer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,7 +16,6 @@ import org.springframework.stereotype.Service;
 public class AwsSqsListenerService {
 
     private final ObjectMapper objectMapper;
-    private final Tracer tracer;
     private final ApplicationEventPublisher eventPublisher;
 
     @SqsListener(value = "${spring.cloud.aws.sqs.nickname-sqs-name}")
@@ -27,30 +24,18 @@ public class AwsSqsListenerService {
         JsonNode messageNode = objectMapper.readTree(messageJson);
         String messageId = messageNode.get("MessageId").asText();  // 메시지 ID 추출
 
-        Span newSpan = tracer.nextSpan().name(messageId).start(); // Span 이름을 메시지 ID로 설정
-        newSpan.tag("messageId", messageId); // messageId 태그 추가
-        newSpan.tag("consumer", "RECIPE"); // consumer 태그 추가
+        // SQS 메시지 처리 로직
+        String messageContent = messageNode.get("Message").asText();
 
-        try (Tracer.SpanInScope ws = tracer.withSpanInScope(newSpan)) {
-            // SQS 메시지 처리 로직
-            String topicArn = messageNode.get("TopicArn").asText();
-            String messageContent = messageNode.get("Message").asText();
+        log.info("[RECIPE] Received message from SQS with messageId: {}", messageId);
 
-            log.info("[RECIPE] Received message from SQS with messageId: {}", messageId);
+        JsonNode message = objectMapper.readTree(messageContent);
+        log.info("Message:  {}", message.toString());
 
-            // Assuming the "Message" is also a JSON string, we parse it to print as JSON object
-            JsonNode message = objectMapper.readTree(messageContent);
-            log.info("Message:  {}", message.toString());
-
-            // memberId 추출후 이벤트 발행
-            JsonNode node = objectMapper.readTree(message.toString());
-            Long memberId = Long.valueOf(node.get("memberId").asText());
-            eventPublisher.publishEvent(new NicknameChangeEvent(memberId));
-
-        } finally {
-            newSpan.finish();
-        }
-
+        // memberId 추출후 이벤트 발행
+        JsonNode node = objectMapper.readTree(message.toString());
+        Long memberId = Long.valueOf(node.get("memberId").asText());
+        eventPublisher.publishEvent(new NicknameChangeEvent(memberId));
     }
 
 }


### PR DESCRIPTION
SQS, SNS 코드 내부에 적은 Logging을 지움

이유는 이제는 Zipkin이 Feign요청을 통해서 추적을 할것이기 때문